### PR TITLE
Static cross builds in Docker with cross-rs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
+mkfile_dir := $(dir $(mkfile_path))
+
+cross-rs:
+	make -C $(mkfile_dir)/nix-rust-rs
+
+cr-clean:
+	make -C $(mkfile_dir)/nix-cross-rs clean
+
+clean: cr-clean

--- a/nix-cross-rs/Dockerfile
+++ b/nix-cross-rs/Dockerfile
@@ -1,0 +1,57 @@
+# The following information is from https://hub.docker.com/r/nixos/nix/tags
+FROM nixos/nix:2.9.0@sha256:13b257cd42db29dc851f9818ea1bc2f9c7128c51fdf000971fa6058c66fbe4b6 as cross-rs_builder
+
+############################################################
+# Step 1: Prepare nixpkgs and cross for deterministic builds
+############################################################
+WORKDIR /build
+# Custom project name
+ENV RUST_PROJECT_NAME="rust-cross-build-nix"
+
+# This commit is tagged as 21.11 in nixpkgs
+# ENV NIXPKGS_COMMIT_SHA="a7ecde854aee5c4c7cd6177f54a99d2c1ff28a31"
+# 22.05
+#ENV NIXPKGS_COMMIT_SHA="ce6aa13369b667ac2542593170993504932eb836"
+# This version has podman 4.2.0, which contains bugfix
+# https://github.com/containers/podman/pull/14787
+ENV NIXPKGS_COMMIT_SHA="692574660e1f1e397b6e48065c931e8758c5ad16"
+# 0.2.4
+ENV CROSS_COMMIT_SHA="4645d937bdae6952d9df38eff3ecb91fd719c3bd"
+
+RUN nix-env --option filter-syscalls false -i git gnused && \
+    mkdir -p /build/nixpkgs && \
+    cd nixpkgs && \
+    git init && \
+    git remote add origin https://github.com/NixOS/nixpkgs.git && \
+    git fetch --depth 1 origin ${NIXPKGS_COMMIT_SHA} && \
+    git checkout FETCH_HEAD && \
+    cd .. && \
+    mkdir -p /build/cross && \
+    git clone https://github.com/cross-rs/cross.git && \
+    cd cross && \
+    git checkout ${CROSS_COMMIT_SHA} && \
+    cd .. && \
+    mkdir -p /build/.cargo && \
+    mkdir -p /build/.rustup && \
+    mkdir -p /build/${RUST_PROJECT_NAME}
+
+ENV NIX_PATH=nixpkgs=/build/nixpkgs
+ENV RUSTC_VERSION=1.63.0
+ENV CARGO_HOME="/build/.cargo"
+ENV RUSTUP_HOME="/build/.rustup"
+ENV PATH="${CARGO_HOME}/bin:${RUSTUP_HOME}/toolchains/${RUSTC_VERSION}-x86_64-unknown-linux-gnu/bin:${PATH}"
+#########################################################
+# Step 2: Prepare Rust project
+#########################################################
+COPY src /build/${RUST_PROJECT_NAME}/src
+COPY Cargo.toml /build/${RUST_PROJECT_NAME}/Cargo.toml
+COPY Cross.toml /build/${RUST_PROJECT_NAME}/Cross.toml
+COPY Cargo.lock /build/${RUST_PROJECT_NAME}/Cargo.lock
+COPY rust-toolchain /build/${RUST_PROJECT_NAME}/rust-toolchain
+COPY nix-cross-rs/nixbuild.sh /build/${RUST_PROJECT_NAME}/nixbuild.sh
+COPY nix-cross-rs/shell.nix /build/${RUST_PROJECT_NAME}/shell.nix
+
+# String substitution
+RUN sed -i "s/RUST_PROJECT_NAME/${RUST_PROJECT_NAME}/g" /build/${RUST_PROJECT_NAME}/nixbuild.sh
+
+ENTRYPOINT [ "/bin/sh", "-c", "exec /build/${RUST_PROJECT_NAME}/nixbuild.sh" ]

--- a/nix-cross-rs/Makefile
+++ b/nix-cross-rs/Makefile
@@ -1,0 +1,10 @@
+mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
+mkfile_dir := $(dir $(mkfile_path))
+
+all: cross-build
+
+cross-build:
+	$(mkfile_dir)/run.sh 2>/dev/null
+
+clean:
+	rm -rf $(mkfile_dir)/out

--- a/nix-cross-rs/nixbuild.sh
+++ b/nix-cross-rs/nixbuild.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# This script is to be invoked inside the container
+
+cd /build/RUST_PROJECT_NAME && \
+    nix-shell shell.nix \
+      --run "cd /build/RUST_PROJECT_NAME && \
+             rustup toolchain install $(cat rust-toolchain) && \
+             cargo install cross --git file:///build/cross && \
+             mkdir -p out && \
+             CROSS_CONTAINER_ENGINE=podman cross build --release --target aarch64-unknown-linux-musl && \
+             cp target/aarch64-unknown-linux-musl/release/hello-random out/hello-random-aarch64-linux && \
+             CROSS_CONTAINER_ENGINE=podman cross build --release --target armv7-unknown-linux-musleabihf && \
+             cp target/armv7-unknown-linux-musleabihf/release/hello-random out/hello-random-armv7-linux && \
+             CROSS_CONTAINER_ENGINE=podman cross build --release --target x86_64-unknown-linux-musl && \
+             cp target/x86_64-unknown-linux-musl/release/hello-random out/hello-random-x86_64-linux && \
+             CROSS_CONTAINER_ENGINE=podman cross build --release --target arm-unknown-linux-musleabihf && \
+             cp target/arm-unknown-linux-musleabihf/release/hello-random out/hello-random-arm-linux"

--- a/nix-cross-rs/run.sh
+++ b/nix-cross-rs/run.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+SCRIPT_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+OUT_DIR="${SCRIPT_DIR}/out"
+REVISION=$(git --work-tree="${SCRIPT_DIR}"/../ --git-dir="${SCRIPT_DIR}"/../.git \
+  rev-parse HEAD)
+BUILDER_TAG_NAME="cross-rs_builder:$REVISION"
+
+echo "Creating builder container image..."
+# Need to run docker build in script's parent directory
+cd "${SCRIPT_DIR}/.."
+docker build -f "${SCRIPT_DIR}/Dockerfile" -t "${BUILDER_TAG_NAME}" .
+docker images "${BUILDER_TAG_NAME}"
+rm -rf "${OUT_DIR}"
+mkdir -p "${OUT_DIR}"
+
+echo "Cross building started..."
+docker run --privileged -v /var/lib/containers/storage -v "${OUT_DIR}":/build/rust-cross-build-nix/out --rm -i "${BUILDER_TAG_NAME}"
+
+echo
+echo "============ HELLO-RANDOM ARTIFACTS INFO ============"
+echo "Artifacts created in ${OUT_DIR}/"
+echo "sha256sums:"
+sha256sum "${OUT_DIR}"/hello-random* | sort -k2
+echo

--- a/nix-cross-rs/shell.nix
+++ b/nix-cross-rs/shell.nix
@@ -1,0 +1,53 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+let
+
+  # To use this shell.nix on NixOS your user needs to be configured as such:
+  users.extraUsers.root = {
+    subUidRanges = [{ startUid = 100000; count = 65536; }];
+    subGidRanges = [{ startGid = 100000; count = 65536; }];
+  };
+
+  # Provides a script that copies required files to ~/
+  podmanSetupScript = let
+    registriesConf = pkgs.writeText "registries.conf" ''
+      [registries.search]
+      registries = ['docker.io']
+
+      [registries.block]
+      registries = []
+    '';
+  in pkgs.writeScript "podman-setup" ''
+    #!${pkgs.runtimeShell}
+
+    # Dont overwrite customised configuration
+    if ! test -f ~/.config/containers/policy.json; then
+      install -Dm555 ${pkgs.skopeo.src}/default-policy.json ~/.config/containers/policy.json
+    fi
+
+    if ! test -f ~/.config/containers/registries.conf; then
+      install -Dm555 ${registriesConf} ~/.config/containers/registries.conf
+    fi
+  '';
+
+in pkgs.mkShell {
+
+  buildInputs = [
+    pkgs.rustup
+    pkgs.gcc
+    pkgs.podman  # Docker compat
+    pkgs.runc  # Container runtime
+    pkgs.conmon  # Container runtime monitor
+    pkgs.skopeo  # Interact with container registry
+    pkgs.slirp4netns  # User-mode networking for unprivileged namespaces
+    pkgs.fuse-overlayfs  # CoW for images, much faster than default vfs
+  ];
+
+  shellHook = ''
+    # Install required configuration
+    ${podmanSetupScript}
+    mkdir -p /opt/cni
+    ln -s ${pkgs.cni-plugins}/bin /opt/cni/bin
+  '';
+
+}


### PR DESCRIPTION
To make the build, run command

    make cross-rs

Sample output

============ HELLO-RANDOM ARTIFACTS INFO ============
Artifacts created in /path/to/rust-cross-build-nix/nix-cross-rs/out/
sha256sums:
fb43ee36510fab7efa1823788d4bf5b83c7b50b89e2b12b6d18a2e9145cc9db4  /path/to/rust-cross-build-nix/nix-cross-rs/out/hello-random-aarch64-linux
2ceea3de9803d1b98476f9f647572c38ae6b21927d318a3f367837c44ae63d26  /path/to/rust-cross-build-nix/nix-cross-rs/out/hello-random-arm-linux
887f6fd5b0e26ff332a9cca9adfc2517cb86143067de8f83240306825ddff16a  /path/to/rust-cross-build-nix/nix-cross-rs/out/hello-random-armv7-linux
6c000231ea6859ce874f2cc54c49ab5d6b9bc0abf07eeca1bc935e28c74130da  /path/to/rust-cross-build-nix/nix-cross-rs/out/hello-random-x86_64-linux

Note that because we need to run a container inside a container for the
`cross-rs` build, we need to run Docker in `priviledged` mode (which is
less ideal than I expect).

Clean up with command

    make clean