### PR TITLE
Add GitHub Actions workflow for cross-rs build

### DIFF
--- a/.github/workflows/r10e-cross-rs-build.yml
+++ b/.github/workflows/r10e-cross-rs-build.yml
@@ -1,0 +1,24 @@
+# Possibly reproducible build with cross-rs and Nix
+name: "Reproducible build with cross-rs"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+    nix-cross-rs-build:
+      name: "r10e cross-rs build"
+      strategy:
+        fail-fast: false
+        matrix:
+          os: [ubuntu-18.04]
+      runs-on: ${{ matrix.os }}
+      steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Cross build artifacts
+        run: |
+          cd ${{ github.workspace }}
+          make cross-rs

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 mkfile_dir := $(dir $(mkfile_path))
 
 cross-rs:
-	make -C $(mkfile_dir)/nix-rust-rs
+	make -C $(mkfile_dir)/nix-cross-rs
 
 cr-clean:
 	make -C $(mkfile_dir)/nix-cross-rs clean


### PR DESCRIPTION
We run this workflow on `ubuntu-18.04`, which appeared to work based on a
local testing. Will try `ubuntu-20.04` later, if this works.