### PR TITLE
Static cross builds in Docker with rust-overlay

### DIFF
--- a/.github/workflows/r10e-rust-overlay-build.yml
+++ b/.github/workflows/r10e-rust-overlay-build.yml
@@ -1,0 +1,24 @@
+# Possibly reproducible build with Nix rust-overlay
+name: "Reproducible build with rust-overlay"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+    nix-cross-rs-build:
+      name: "r10e rust-overlay build"
+      strategy:
+        fail-fast: false
+        matrix:
+          os: [ubuntu-18.04]
+      runs-on: ${{ matrix.os }}
+      steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Cross build artifacts
+        run: |
+          cd ${{ github.workspace }}
+          make rust-overlay

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,20 @@
 mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 mkfile_dir := $(dir $(mkfile_path))
 
+.PHONY: cross-rs rust-overlay cr-clean ro-clean clean
+
+all: cross-rs rust-overlay
+
 cross-rs:
 	make -C $(mkfile_dir)/nix-cross-rs
 
 cr-clean:
 	make -C $(mkfile_dir)/nix-cross-rs clean
 
-clean: cr-clean
+rust-overlay:
+	make -C $(mkfile_dir)/nix-rust-overlay r10e-build
+
+ro-clean:
+	make -C $(mkfile_dir)/nix-rust-overlay clean
+
+clean: cr-clean ro-clean

--- a/nix-rust-overlay/Dockerfile
+++ b/nix-rust-overlay/Dockerfile
@@ -1,0 +1,52 @@
+# The following information is from https://hub.docker.com/r/nixos/nix/tags
+FROM nixos/nix:2.9.0@sha256:13b257cd42db29dc851f9818ea1bc2f9c7128c51fdf000971fa6058c66fbe4b6 as cross-rs_builder
+
+###################################################################
+# Step 1: Prepare nixpkgs and rust-overlay for deterministic builds
+###################################################################
+WORKDIR /build
+# Custom project name
+ENV RUST_PROJECT_NAME="rust-cross-build-nix"
+
+# nixpkgs 22.05
+ENV NIXPKGS_COMMIT_SHA="ce6aa13369b667ac2542593170993504932eb836"
+# rust-overlay version 20220827
+ENV RUST_OVERLAY_COMMIT_SHA="0c4c1432353e12b325d1472bea99e364871d2cb3"
+
+RUN nix-env --option filter-syscalls false -i git && \
+    mkdir -p /build/nixpkgs && \
+    cd nixpkgs && \
+    git init && \
+    git remote add origin https://github.com/NixOS/nixpkgs.git && \
+    git fetch --depth 1 origin ${NIXPKGS_COMMIT_SHA} && \
+    git checkout FETCH_HEAD && \
+    cd .. && \
+    mkdir -p /build/cross && \
+    git clone https://github.com/oxalica/rust-overlay.git && \
+    cd rust-overlay && \
+    git checkout ${CROSS_COMMIT_SHA} && \
+    cd .. && \
+    mkdir -p /build/${RUST_PROJECT_NAME}/out
+
+ENV NIX_PATH=nixpkgs=/build/nixpkgs:rust-overlay=/build/rust-overlay
+#########################################################
+# Step 2: Prepare Rust project
+#########################################################
+COPY src /build/${RUST_PROJECT_NAME}/src
+COPY Cargo.toml /build/${RUST_PROJECT_NAME}/Cargo.toml
+COPY Cargo.lock /build/${RUST_PROJECT_NAME}/Cargo.lock
+COPY nix-rust-overlay/shell-aarch64.nix /build/${RUST_PROJECT_NAME}/shell-aarch64.nix
+COPY nix-rust-overlay/shell-armv7.nix /build/${RUST_PROJECT_NAME}/shell-armv7.nix
+COPY nix-rust-overlay/Makefile /build/${RUST_PROJECT_NAME}/Makefile
+
+#########################################################
+# Step 3: Cross builds for various targets
+#########################################################
+RUN cd /build/${RUST_PROJECT_NAME} && \
+    nix-shell shell-aarch64.nix \
+      --run "TARGET=aarch64-unknown-linux-musl make && \
+             TARGET=aarch64-unknown-linux-musl make run"
+RUN cd /build/${RUST_PROJECT_NAME} && \
+    nix-shell shell-armv7.nix \
+      --run "TARGET=armv7-unknown-linux-musleabihf make && \
+             TARGET=armv7-unknown-linux-musleabihf make run"

--- a/nix-rust-overlay/Makefile
+++ b/nix-rust-overlay/Makefile
@@ -1,0 +1,24 @@
+# This Makefile is expected to be run inside nix-shell.
+TARGET ?= x86_64-unknown-linux-musl
+CARGO_FLAGS := --release --target $(TARGET)
+
+mkfile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
+mkfile_dir := $(dir $(mkfile_path))
+
+.PHONY: all
+all: Cargo.toml Cargo.lock src/main.rs
+	cargo build $(CARGO_FLAGS)
+	cp target/$(TARGET)/release/hello-random out/hello-random-$(TARGET)
+
+.PHONY: run
+run: all
+	cargo run $(CARGO_FLAGS)
+
+# This target calls other targets to build reproducible artifacts
+.PHONY: r10e-build
+r10e-build: Dockerfile run.sh
+	$(mkfile_dir)/run.sh 2>/dev/null
+
+.PHONY: clean
+clean:
+	rm -rf $(mkfile_dir)/out

--- a/nix-rust-overlay/Makefile.armv7
+++ b/nix-rust-overlay/Makefile.armv7
@@ -1,0 +1,11 @@
+# This Makefile is expected to be run inside nix-shell.
+
+CARGO_FLAGS := --target armv7-unknown-linux-musleabihf
+
+.PHONY: all
+all: Cargo.toml Cargo.lock src/main.rs
+	cargo build $(CARGO_FLAGS)
+
+.PHONY: test
+run: all
+	cargo run $(CARGO_FLAGS)

--- a/nix-rust-overlay/run.sh
+++ b/nix-rust-overlay/run.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+SCRIPT_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+OUT_DIR="${SCRIPT_DIR}/out"
+REVISION=$(git --work-tree="${SCRIPT_DIR}"/../ --git-dir="${SCRIPT_DIR}"/../.git \
+  rev-parse HEAD)
+BUILDER_TAG_NAME="rust-overlay_builder:$REVISION"
+
+echo "Creating builder container image..."
+# Need to run docker build in script's parent directory
+cd "${SCRIPT_DIR}/.."
+docker build -f "${SCRIPT_DIR}/Dockerfile" -t "${BUILDER_TAG_NAME}" .
+docker images "${BUILDER_TAG_NAME}"
+rm -rf "${OUT_DIR}"
+mkdir -p "${OUT_DIR}"
+
+echo "Cross building started..."
+docker run -v "${OUT_DIR}":/tmp/out_rust-overlay --rm -i "${BUILDER_TAG_NAME}" << CMD
+mkdir -p /tmp/out_rust-overlay && \
+cp -r /build/rust-cross-build-nix/out/* /tmp/out_rust-overlay/
+CMD
+
+echo
+echo "============ HELLO-RANDOM ARTIFACTS INFO ============"
+echo "Artifacts created in ${OUT_DIR}/"
+echo "sha256sums:"
+sha256sum "${OUT_DIR}"/hello-random* | sort -k2
+echo

--- a/nix-rust-overlay/shell-aarch64.nix
+++ b/nix-rust-overlay/shell-aarch64.nix
@@ -1,0 +1,21 @@
+# h/t https://github.com/oxalica/rust-overlay/tree/master/examples/cross-aarch64
+# When invoking with `nix-shell`, add "rust-overlay=/path/to/rust-overlay/dir"
+# to $NIX_PATH
+(import <nixpkgs> {
+  crossSystem = "aarch64-linux";
+  overlays = [ (import <rust-overlay>) ];
+}).pkgsMusl.pkgsStatic.callPackage (
+{ mkShell, stdenv, rust-bin, pkg-config, qemu }:
+mkShell {
+  nativeBuildInputs = [
+    rust-bin.stable.latest.default
+    pkg-config
+  ];
+
+  depsBuildBuild = [ qemu ];
+
+  buildInputs = [ ];
+
+  CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER = "${stdenv.cc.targetPrefix}cc";
+  CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUNNER = "qemu-aarch64";
+}) {}

--- a/nix-rust-overlay/shell-armv7.nix
+++ b/nix-rust-overlay/shell-armv7.nix
@@ -1,0 +1,21 @@
+# h/t https://github.com/oxalica/rust-overlay/tree/master/examples/cross-aarch64
+# When invoking with `nix-shell`, add "rust-overlay=/path/to/rust-overlay/dir"
+# to $NIX_PATH
+(import <nixpkgs> {
+  crossSystem = "armv7l-linux";
+  overlays = [ (import <rust-overlay>) ];
+}).pkgsMusl.pkgsStatic.callPackage (
+{ mkShell, stdenv, rust-bin, pkg-config, qemu }:
+mkShell {
+  nativeBuildInputs = [
+    rust-bin.stable.latest.default
+    pkg-config
+  ];
+
+  depsBuildBuild = [ qemu ];
+
+  buildInputs = [ ];
+
+  CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_LINKER = "${stdenv.cc.targetPrefix}cc";
+  CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_RUNNER = "qemu-arm";
+}) {}


### PR DESCRIPTION
To make the build, run command

    make rust-overlay

Sample output

```text
============ HELLO-RANDOM ARTIFACTS INFO ============
Artifacts created in /path/to/rust-cross-build-nix/nix-rust-overlay/out/
sha256sums:
f83574742f7b4c71cf1d420dc499762030b1d204046f0331341450cb27cb089b  /path/to/rust-cross-build-nix/nix-rust-overlay/out/hello-random-aarch64-unknown-linux-musl
7249049075784413c3ae31650898de7a84f1f2e9e8d9492af881362a0e04e30f  /path/to/rust-cross-build-nix/nix-rust-overlay/out/hello-random-armv7-unknown-linux-musleabihf
```

Clean up with command

    make ro-clean

In this approach, we use https://github.com/oxalica/rust-overlay for
reproducible Rust builds, where the resulting binaries are built against
`musl`. Nix FTW.