### PR TITLE
Add a couple more cross targets for nix-rust-overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,25 @@ reproducible. The examples also statically link against `musl` libc, because
 static linking is trickier to do, and because we can.
 
 You need Docker for building the examples.
+
+## Approach 1
+
+[nix-cross-rs](./nix-cross-rs/)
+
+## Approach 2
+
+[nix-rust-overlay](./nix-rust-overlay/)
+
+## How to Build Using Both Approaches
+
+In the directory root of the repository
+
+```bash
+make
+```
+
+Clean up with command
+
+```bash
+make clean
+```

--- a/nix-cross-rs/README.md
+++ b/nix-cross-rs/README.md
@@ -7,8 +7,9 @@ for cross-building, and the latter makes the builds reproducible.
 
 ## How to build
 
+In the directory root of the repository
+
 ```bash
-cd nix-cross-rs
-make
-# `make clean` to clean up
+make cross-rs
+# `make cr-clean` to clean up
 ```

--- a/nix-rust-overlay/Dockerfile
+++ b/nix-rust-overlay/Dockerfile
@@ -30,23 +30,40 @@ RUN nix-env --option filter-syscalls false -i git && \
 
 ENV NIX_PATH=nixpkgs=/build/nixpkgs:rust-overlay=/build/rust-overlay
 #########################################################
-# Step 2: Prepare Rust project
+# Step 2: Prepare Nix Shells for Caching
 #########################################################
-COPY src /build/${RUST_PROJECT_NAME}/src
-COPY Cargo.toml /build/${RUST_PROJECT_NAME}/Cargo.toml
-COPY Cargo.lock /build/${RUST_PROJECT_NAME}/Cargo.lock
-COPY nix-rust-overlay/shell-aarch64.nix /build/${RUST_PROJECT_NAME}/shell-aarch64.nix
+COPY nix-rust-overlay/shell-x86_64.nix /build/${RUST_PROJECT_NAME}/shell-x86_64.nix
 COPY nix-rust-overlay/shell-armv7.nix /build/${RUST_PROJECT_NAME}/shell-armv7.nix
-COPY nix-rust-overlay/Makefile /build/${RUST_PROJECT_NAME}/Makefile
+COPY nix-rust-overlay/shell-armv6.nix /build/${RUST_PROJECT_NAME}/shell-armv6.nix
+COPY nix-rust-overlay/shell-aarch64.nix /build/${RUST_PROJECT_NAME}/shell-aarch64.nix
+
+RUN cd /build/${RUST_PROJECT_NAME} && \
+    nix-shell shell-x86_64.nix && \
+    nix-shell shell-armv6.nix && \
+    nix-shell shell-armv7.nix && \
+    nix-shell shell-aarch64.nix
 
 #########################################################
 # Step 3: Cross builds for various targets
 #########################################################
+COPY src /build/${RUST_PROJECT_NAME}/src
+COPY Cargo.toml /build/${RUST_PROJECT_NAME}/Cargo.toml
+COPY Cargo.lock /build/${RUST_PROJECT_NAME}/Cargo.lock
+COPY nix-rust-overlay/Makefile /build/${RUST_PROJECT_NAME}/Makefile
+
 RUN cd /build/${RUST_PROJECT_NAME} && \
-    nix-shell shell-aarch64.nix \
-      --run "TARGET=aarch64-unknown-linux-musl make && \
-             TARGET=aarch64-unknown-linux-musl make run"
+    nix-shell shell-x86_64.nix \
+      --run "TARGET=x86_64-unknown-linux-musl make && \
+             TARGET=x86_64-unknown-linux-musl make run"
+RUN cd /build/${RUST_PROJECT_NAME} && \
+    nix-shell shell-armv6.nix \
+      --run "TARGET=arm-unknown-linux-musleabihf make && \
+             TARGET=arm-unknown-linux-musleabihf make run"
 RUN cd /build/${RUST_PROJECT_NAME} && \
     nix-shell shell-armv7.nix \
       --run "TARGET=armv7-unknown-linux-musleabihf make && \
              TARGET=armv7-unknown-linux-musleabihf make run"
+RUN cd /build/${RUST_PROJECT_NAME} && \
+    nix-shell shell-aarch64.nix \
+      --run "TARGET=aarch64-unknown-linux-musl make && \
+             TARGET=aarch64-unknown-linux-musl make run"

--- a/nix-rust-overlay/Makefile
+++ b/nix-rust-overlay/Makefile
@@ -7,7 +7,7 @@ mkfile_dir := $(dir $(mkfile_path))
 
 .PHONY: all
 all: Cargo.toml Cargo.lock src/main.rs
-	cargo build $(CARGO_FLAGS)
+	cargo build -vv --locked $(CARGO_FLAGS)
 	cp target/$(TARGET)/release/hello-random out/hello-random-$(TARGET)
 
 .PHONY: run
@@ -17,7 +17,7 @@ run: all
 # This target calls other targets to build reproducible artifacts
 .PHONY: r10e-build
 r10e-build: Dockerfile run.sh
-	$(mkfile_dir)/run.sh 2>/dev/null
+	$(mkfile_dir)/run.sh
 
 .PHONY: clean
 clean:

--- a/nix-rust-overlay/README.md
+++ b/nix-rust-overlay/README.md
@@ -1,0 +1,14 @@
+# Reproducible Rust Cross Builds with rust-overlay
+
+This approach to deterministically building statically linked Rust binaries is
+based on [Nix](https://github.com/NixOS/nixpkgs) and
+[rust-overlay](https://github.com/oxalica/rust-overlay).
+
+## How to build
+
+In the directory root of the repository
+
+```bash
+make rust-overlay
+# `make ro-clean` to clean up
+```

--- a/nix-rust-overlay/shell-armv6.nix
+++ b/nix-rust-overlay/shell-armv6.nix
@@ -1,0 +1,21 @@
+# h/t https://github.com/oxalica/rust-overlay/tree/master/examples/cross-aarch64
+# When invoking with `nix-shell`, add "rust-overlay=/path/to/rust-overlay/dir"
+# to $NIX_PATH
+(import <nixpkgs> {
+  crossSystem = "armv6l-linux";
+  overlays = [ (import <rust-overlay>) ];
+}).pkgsMusl.pkgsStatic.callPackage (
+{ mkShell, stdenv, rust-bin, pkg-config, qemu }:
+mkShell {
+  nativeBuildInputs = [
+    rust-bin.stable.latest.default
+    pkg-config
+  ];
+
+  depsBuildBuild = [ qemu ];
+
+  buildInputs = [ ];
+
+  CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABIHF_LINKER = "${stdenv.cc.targetPrefix}cc";
+  CARGO_TARGET_ARM_UNKNOWN_LINUX_MUSLEABIHF_RUNNER = "qemu-arm";
+}) {}

--- a/nix-rust-overlay/shell-x86_64.nix
+++ b/nix-rust-overlay/shell-x86_64.nix
@@ -1,0 +1,21 @@
+# h/t https://github.com/oxalica/rust-overlay/tree/master/examples/cross-aarch64
+# When invoking with `nix-shell`, add "rust-overlay=/path/to/rust-overlay/dir"
+# to $NIX_PATH
+(import <nixpkgs> {
+  crossSystem = "x86_64-linux";
+  overlays = [ (import <rust-overlay>) ];
+}).pkgsMusl.pkgsStatic.callPackage (
+{ mkShell, stdenv, rust-bin, pkg-config, qemu }:
+mkShell {
+  nativeBuildInputs = [
+    rust-bin.stable.latest.default
+    pkg-config
+  ];
+
+  depsBuildBuild = [ qemu ];
+
+  buildInputs = [ ];
+
+  CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER = "${stdenv.cc.targetPrefix}cc";
+  CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_RUNNER = "qemu-x86_64";
+}) {}


### PR DESCRIPTION
Add targets `x86_64-unknown-linux-musl` and `arm-unknown-linux-musleabihf`.

Update documentation.