### PR TITLE
Support build on Apple M1

### DIFF
--- a/nix-cross-rs/Dockerfile
+++ b/nix-cross-rs/Dockerfile
@@ -18,6 +18,10 @@ ENV NIXPKGS_COMMIT_SHA="692574660e1f1e397b6e48065c931e8758c5ad16"
 # 0.2.4
 ENV CROSS_COMMIT_SHA="4645d937bdae6952d9df38eff3ecb91fd719c3bd"
 
+# Apple M1 workaround
+COPY nix.conf /build/nix.conf
+ENV NIX_USER_CONF_FILES=/build/nix.conf
+
 RUN nix-env --option filter-syscalls false -i git gnused && \
     mkdir -p /build/nixpkgs && \
     cd nixpkgs && \
@@ -40,6 +44,7 @@ ENV RUSTC_VERSION=1.63.0
 ENV CARGO_HOME="/build/.cargo"
 ENV RUSTUP_HOME="/build/.rustup"
 ENV PATH="${CARGO_HOME}/bin:${RUSTUP_HOME}/toolchains/${RUSTC_VERSION}-x86_64-unknown-linux-gnu/bin:${PATH}"
+
 #########################################################
 # Step 2: Prepare Rust project
 #########################################################

--- a/nix-cross-rs/run.sh
+++ b/nix-cross-rs/run.sh
@@ -17,7 +17,7 @@ rm -rf "${OUT_DIR}"
 mkdir -p "${OUT_DIR}"
 
 echo "Cross building started..."
-docker run --privileged -v /var/lib/containers/storage -v "${OUT_DIR}":/build/rust-cross-build-nix/out --rm -i "${BUILDER_TAG_NAME}"
+docker run --platform linux/amd64 --privileged -v /var/lib/containers/storage -v "${OUT_DIR}":/build/rust-cross-build-nix/out --rm -i "${BUILDER_TAG_NAME}"
 
 echo
 echo "============ HELLO-RANDOM ARTIFACTS INFO ============"

--- a/nix-cross-rs/run.sh
+++ b/nix-cross-rs/run.sh
@@ -11,7 +11,7 @@ BUILDER_TAG_NAME="cross-rs_builder:$REVISION"
 echo "Creating builder container image..."
 # Need to run docker build in script's parent directory
 cd "${SCRIPT_DIR}/.."
-docker build -f "${SCRIPT_DIR}/Dockerfile" -t "${BUILDER_TAG_NAME}" .
+docker build --platform linux/amd64 -f "${SCRIPT_DIR}/Dockerfile" -t "${BUILDER_TAG_NAME}" .
 docker images "${BUILDER_TAG_NAME}"
 rm -rf "${OUT_DIR}"
 mkdir -p "${OUT_DIR}"

--- a/nix-rust-overlay/Dockerfile
+++ b/nix-rust-overlay/Dockerfile
@@ -13,7 +13,11 @@ ENV NIXPKGS_COMMIT_SHA="ce6aa13369b667ac2542593170993504932eb836"
 # rust-overlay version 20220827
 ENV RUST_OVERLAY_COMMIT_SHA="0c4c1432353e12b325d1472bea99e364871d2cb3"
 
-RUN nix-env --option filter-syscalls false -i git && \
+# Apple M1 workaround
+COPY nix.conf /build/nix.conf
+ENV NIX_USER_CONF_FILES=/build/nix.conf
+
+RUN nix-env -i git && \
     mkdir -p /build/nixpkgs && \
     cd nixpkgs && \
     git init && \
@@ -29,6 +33,7 @@ RUN nix-env --option filter-syscalls false -i git && \
     mkdir -p /build/${RUST_PROJECT_NAME}/out
 
 ENV NIX_PATH=nixpkgs=/build/nixpkgs:rust-overlay=/build/rust-overlay
+
 #########################################################
 # Step 2: Prepare Nix Shells for Caching
 #########################################################

--- a/nix-rust-overlay/Dockerfile
+++ b/nix-rust-overlay/Dockerfile
@@ -56,19 +56,20 @@ COPY Cargo.toml /build/${RUST_PROJECT_NAME}/Cargo.toml
 COPY Cargo.lock /build/${RUST_PROJECT_NAME}/Cargo.lock
 COPY nix-rust-overlay/Makefile /build/${RUST_PROJECT_NAME}/Makefile
 
+# echo to NOP qemu commands to get around issue on Apple M1
 RUN cd /build/${RUST_PROJECT_NAME} && \
     nix-shell shell-x86_64.nix \
       --run "TARGET=x86_64-unknown-linux-musl make && \
-             TARGET=x86_64-unknown-linux-musl make run"
+             echo TARGET=x86_64-unknown-linux-musl make run"
 RUN cd /build/${RUST_PROJECT_NAME} && \
     nix-shell shell-armv6.nix \
       --run "TARGET=arm-unknown-linux-musleabihf make && \
-             TARGET=arm-unknown-linux-musleabihf make run"
+             echo TARGET=arm-unknown-linux-musleabihf make run"
 RUN cd /build/${RUST_PROJECT_NAME} && \
     nix-shell shell-armv7.nix \
       --run "TARGET=armv7-unknown-linux-musleabihf make && \
-             TARGET=armv7-unknown-linux-musleabihf make run"
+             echo TARGET=armv7-unknown-linux-musleabihf make run"
 RUN cd /build/${RUST_PROJECT_NAME} && \
     nix-shell shell-aarch64.nix \
       --run "TARGET=aarch64-unknown-linux-musl make && \
-             TARGET=aarch64-unknown-linux-musl make run"
+             echo TARGET=aarch64-unknown-linux-musl make run"

--- a/nix-rust-overlay/run.sh
+++ b/nix-rust-overlay/run.sh
@@ -11,7 +11,7 @@ BUILDER_TAG_NAME="rust-overlay_builder:$REVISION"
 echo "Creating builder container image..."
 # Need to run docker build in script's parent directory
 cd "${SCRIPT_DIR}/.."
-docker build -f "${SCRIPT_DIR}/Dockerfile" -t "${BUILDER_TAG_NAME}" .
+docker build --platform linux/amd64 -f "${SCRIPT_DIR}/Dockerfile" -t "${BUILDER_TAG_NAME}" .
 docker images "${BUILDER_TAG_NAME}"
 rm -rf "${OUT_DIR}"
 mkdir -p "${OUT_DIR}"

--- a/nix-rust-overlay/run.sh
+++ b/nix-rust-overlay/run.sh
@@ -17,7 +17,7 @@ rm -rf "${OUT_DIR}"
 mkdir -p "${OUT_DIR}"
 
 echo "Cross building started..."
-docker run -v "${OUT_DIR}":/tmp/out_rust-overlay --rm -i "${BUILDER_TAG_NAME}" << CMD
+docker run --platform linux/amd64 -v "${OUT_DIR}":/tmp/out_rust-overlay --rm -i "${BUILDER_TAG_NAME}" << CMD
 mkdir -p /tmp/out_rust-overlay && \
 cp -r /build/rust-cross-build-nix/out/* /tmp/out_rust-overlay/
 CMD

--- a/nix.conf
+++ b/nix.conf
@@ -1,0 +1,3 @@
+# cf https://nixos.org/manual/nix/stable/command-ref/conf-file.html
+# Workaround for Apple M1
+filter-syscalls = false


### PR DESCRIPTION
Add a workaround to make the build work also on Apple M1.

Skip sanity checks for rust-overlay builds to work around a `qemu` run failure on M1 in Docker.