### PR TITLE
Use ubuntu-latest runner for GHA workflows

### DIFF
--- a/.github/workflows/r10e-cross-rs-build.yml
+++ b/.github/workflows/r10e-cross-rs-build.yml
@@ -13,7 +13,7 @@ jobs:
       strategy:
         fail-fast: false
         matrix:
-          os: [ubuntu-18.04]
+          os: [ubuntu-latest]
       runs-on: ${{ matrix.os }}
       steps:
       - name: Checkout repository

--- a/.github/workflows/r10e-rust-overlay-build.yml
+++ b/.github/workflows/r10e-rust-overlay-build.yml
@@ -13,7 +13,7 @@ jobs:
       strategy:
         fail-fast: false
         matrix:
-          os: [ubuntu-18.04]
+          os: [ubuntu-latest]
       runs-on: ${{ matrix.os }}
       steps:
       - name: Checkout repository


### PR DESCRIPTION
Replace ubuntu-18.04 with ubuntu-latest.