### PR TITLE
Use tstd crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "cc"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+dependencies = [
+ "jobserver",
+]
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,6 +22,16 @@ name = "hello-random"
 version = "0.1.0"
 dependencies = [
  "rand 0.3.23",
+ "zstd",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -89,3 +108,32 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.1+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
+dependencies = [
+ "cc",
+ "libc",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,8 +112,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "zstd"
 version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+source = "git+https://github.com/gyscos/zstd-rs?rev=56c8b52b6d448e376e746fc062077f68febc03a3#56c8b52b6d448e376e746fc062077f68febc03a3"
 dependencies = [
  "zstd-safe",
 ]
@@ -121,8 +120,7 @@ dependencies = [
 [[package]]
 name = "zstd-safe"
 version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+source = "git+https://github.com/gyscos/zstd-rs?rev=56c8b52b6d448e376e746fc062077f68febc03a3#56c8b52b6d448e376e746fc062077f68febc03a3"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -131,8 +129,7 @@ dependencies = [
 [[package]]
 name = "zstd-sys"
 version = "2.0.1+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
+source = "git+https://github.com/gyscos/zstd-rs?rev=56c8b52b6d448e376e746fc062077f68febc03a3#56c8b52b6d448e376e746fc062077f68febc03a3"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "zstd"
 version = "0.11.2+zstd.1.5.2"
-source = "git+https://github.com/gyscos/zstd-rs?rev=56c8b52b6d448e376e746fc062077f68febc03a3#56c8b52b6d448e376e746fc062077f68febc03a3"
+source = "git+https://github.com/syncom/zstd-rs?rev=abbc3b6a21c9825243933cbb6778781608db56dc#abbc3b6a21c9825243933cbb6778781608db56dc"
 dependencies = [
  "zstd-safe",
 ]
@@ -120,7 +120,7 @@ dependencies = [
 [[package]]
 name = "zstd-safe"
 version = "5.0.2+zstd.1.5.2"
-source = "git+https://github.com/gyscos/zstd-rs?rev=56c8b52b6d448e376e746fc062077f68febc03a3#56c8b52b6d448e376e746fc062077f68febc03a3"
+source = "git+https://github.com/syncom/zstd-rs?rev=abbc3b6a21c9825243933cbb6778781608db56dc#abbc3b6a21c9825243933cbb6778781608db56dc"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -129,7 +129,7 @@ dependencies = [
 [[package]]
 name = "zstd-sys"
 version = "2.0.1+zstd.1.5.2"
-source = "git+https://github.com/gyscos/zstd-rs?rev=56c8b52b6d448e376e746fc062077f68febc03a3#56c8b52b6d448e376e746fc062077f68febc03a3"
+source = "git+https://github.com/syncom/zstd-rs?rev=abbc3b6a21c9825243933cbb6778781608db56dc#abbc3b6a21c9825243933cbb6778781608db56dc"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 rand = "0.3.14"
-# The following commit results in a successful build
-zstd = { git = "https://github.com/gyscos/zstd-rs", rev ="56c8b52b6d448e376e746fc062077f68febc03a3" }
-# The following commit is immediately after the above one, and breaks cross builds
+# The following commit breaks cross builds
 #zstd = { git = "https://github.com/gyscos/zstd-rs", rev ="f0d8a12f0f520095cf26a0dac35b8d0939277add" }
+# The following commit results in a successful build, which reverts the above commit
+zstd = { git = "https://github.com/syncom/zstd-rs", rev ="abbc3b6a21c9825243933cbb6778781608db56dc" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2021"
 
 [dependencies]
 rand = "0.3.14"
+zstd = "0.11.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 rand = "0.3.14"
-zstd = "0.11.2"
+# The following commit results in a successful build
+zstd = { git = "https://github.com/gyscos/zstd-rs", rev ="56c8b52b6d448e376e746fc062077f68febc03a3" }
+# The following commit is immediately after the above one, and breaks cross builds
+#zstd = { git = "https://github.com/gyscos/zstd-rs", rev ="f0d8a12f0f520095cf26a0dac35b8d0939277add" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
 extern crate rand;
+extern crate zstd;
 use rand::Rng;
 
 fn main() {
     let rn = rand::thread_rng().gen_range(38, 45);
     println!("Hello, random: {}", rn);
+    println!("ZSTD default compression level: {}", zstd::DEFAULT_COMPRESSION_LEVEL);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,19 @@
 extern crate rand;
 extern crate zstd;
+use std::io::Write;
+
 use rand::Rng;
 
-fn main() {
+fn main() -> std::io::Result<()> {
     let rn = rand::thread_rng().gen_range(38, 45);
     println!("Hello, random: {}", rn);
     println!("ZSTD default compression level: {}", zstd::DEFAULT_COMPRESSION_LEVEL);
+
+    let mut infile = std::fs::File::create("infile")?;
+    let mut outfile = std::fs::OpenOptions::new().write(true).create(true).open("outfile")?;
+    infile.write_all(b"Hello, random")?;
+    let infile1 = std::fs::File::open("infile")?;
+    zstd::stream::copy_encode(&infile1, &mut outfile, 0)?;
+
+    Ok(())
 }


### PR DESCRIPTION
This is to reproduce an issue related to a recent tstd-rs change for aarch64 build.

The problematic change in tstd is
https://github.com/gyscos/zstd-rs/commit/f0d8a12f0f520095cf26a0dac35b8d0939277add.