### PR TITLE
Make rust version more explicit in rust-overlay

### DIFF
--- a/nix-rust-overlay/shell-aarch64.nix
+++ b/nix-rust-overlay/shell-aarch64.nix
@@ -8,7 +8,7 @@
 { mkShell, stdenv, rust-bin, pkg-config, openssl, qemu }:
 mkShell {
   nativeBuildInputs = [
-    rust-bin.stable.latest.minimal
+    rust-bin.stable."1.63.0".minimal
     pkg-config
   ];
 

--- a/nix-rust-overlay/shell-armv6.nix
+++ b/nix-rust-overlay/shell-armv6.nix
@@ -8,7 +8,7 @@
 { mkShell, stdenv, rust-bin, pkg-config, openssl, qemu }:
 mkShell {
   nativeBuildInputs = [
-    rust-bin.stable.latest.minimal
+    rust-bin.stable."1.63.0".minimal
     pkg-config
   ];
 

--- a/nix-rust-overlay/shell-armv7.nix
+++ b/nix-rust-overlay/shell-armv7.nix
@@ -8,7 +8,7 @@
 { mkShell, stdenv, rust-bin, pkg-config, openssl, qemu }:
 mkShell {
   nativeBuildInputs = [
-    rust-bin.stable.latest.minimal
+    rust-bin.stable."1.63.0".minimal
     pkg-config
   ];
 

--- a/nix-rust-overlay/shell-x86_64.nix
+++ b/nix-rust-overlay/shell-x86_64.nix
@@ -8,7 +8,7 @@
 { mkShell, stdenv, rust-bin, pkg-config, openssl, qemu }:
 mkShell {
   nativeBuildInputs = [
-    rust-bin.stable.latest.minimal
+    rust-bin.stable."1.63.0".minimal
     pkg-config
   ];
 


### PR DESCRIPTION
In `nix-rust-oerlay/shell-*.nix`, we use the more explicit rust-bin.stable."1.63.0" instead of rust-bin.stable.latest to specify the rust verison, although these two specifications are equivalent for the currently pinned nixpkgs revision.

This makes it easier to figure out what rust version is being used.