### PR TITLE
Selectively ignore paths in r10e CI pipelines

### DIFF
--- a/.github/workflows/r10e-cross-rs-build.yml
+++ b/.github/workflows/r10e-cross-rs-build.yml
@@ -3,9 +3,15 @@ name: "Reproducible build with cross-rs"
 
 on:
   push:
-    branches: [main]
+    paths-ignore:
+    - 'nix-rust-overlay/**'
+    branches:
+    - 'main'
   pull_request:
-    branches: [main]
+    paths-ignore:
+    - 'nix-rust-overlay/**'
+    branches:
+    - 'main'
 
 jobs:
     nix-cross-rs-build:

--- a/.github/workflows/r10e-rust-overlay-build.yml
+++ b/.github/workflows/r10e-rust-overlay-build.yml
@@ -3,9 +3,15 @@ name: "Reproducible build with rust-overlay"
 
 on:
   push:
-    branches: [main]
+    paths-ignore:
+    - 'nix-cross-rs/**'
+    branches:
+    - 'main'
   pull_request:
-    branches: [main]
+    paths-ignore:
+    - 'nix-cross-rs/**'
+    branches:
+    - 'main'
 
 jobs:
     nix-cross-rs-build:


### PR DESCRIPTION
Ignore nix-cross-rs/ in rust-overlay pipeline.
Ignore nix-rust-overlay/ in cross-rs pipeline.