### PR TITLE
Add dependabot custom configuration for cargo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      # Cf. https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+      timezone: "Etc/GMT"
+      time: "11:42"
+    # Disable version updates for cargo dependencies
+    open-pull-requests-limit: 0

--- a/nix-cross-rs/Dockerfile
+++ b/nix-cross-rs/Dockerfile
@@ -8,8 +8,6 @@ WORKDIR /build
 # Custom project name
 ENV RUST_PROJECT_NAME="rust-cross-build-nix"
 
-# This commit is tagged as 21.11 in nixpkgs
-# ENV NIXPKGS_COMMIT_SHA="a7ecde854aee5c4c7cd6177f54a99d2c1ff28a31"
 # 22.05
 #ENV NIXPKGS_COMMIT_SHA="ce6aa13369b667ac2542593170993504932eb836"
 # This version has podman 4.2.0, which contains bugfix


### PR DESCRIPTION
We'd like to get dependabot security updates, but not version updates, to reduce the amount of noise. Add a custom configuration for this.