### PR TITLE
rust-overlay: upgrade rust to 1.69.0

### DIFF
--- a/nix-rust-overlay/shell-aarch64.nix
+++ b/nix-rust-overlay/shell-aarch64.nix
@@ -8,7 +8,7 @@
 { mkShell, stdenv, rust-bin, pkg-config, openssl, qemu }:
 mkShell {
   nativeBuildInputs = [
-    rust-bin.stable."1.65.0".minimal
+    rust-bin.stable."1.69.0".minimal
     pkg-config
   ];
 

--- a/nix-rust-overlay/shell-armv6.nix
+++ b/nix-rust-overlay/shell-armv6.nix
@@ -8,7 +8,7 @@
 { mkShell, stdenv, rust-bin, pkg-config, openssl, qemu }:
 mkShell {
   nativeBuildInputs = [
-    rust-bin.stable."1.65.0".minimal
+    rust-bin.stable."1.69.0".minimal
     pkg-config
   ];
 

--- a/nix-rust-overlay/shell-armv7.nix
+++ b/nix-rust-overlay/shell-armv7.nix
@@ -8,7 +8,7 @@
 { mkShell, stdenv, rust-bin, pkg-config, openssl, qemu }:
 mkShell {
   nativeBuildInputs = [
-    rust-bin.stable."1.65.0".minimal
+    rust-bin.stable."1.69.0".minimal
     pkg-config
   ];
 

--- a/nix-rust-overlay/shell-x86_64-win.nix
+++ b/nix-rust-overlay/shell-x86_64-win.nix
@@ -10,7 +10,7 @@
 { mkShell, stdenv, rust-bin, windows, wine64, pkg-config }:
 mkShell {
   nativeBuildInputs = [
-    rust-bin.stable."1.65.0".minimal
+    rust-bin.stable."1.69.0".minimal
     pkg-config
   ];
 

--- a/nix-rust-overlay/shell-x86_64.nix
+++ b/nix-rust-overlay/shell-x86_64.nix
@@ -8,7 +8,7 @@
 { mkShell, stdenv, rust-bin, pkg-config, openssl, qemu }:
 mkShell {
   nativeBuildInputs = [
-    rust-bin.stable."1.65.0".minimal
+    rust-bin.stable."1.69.0".minimal
     pkg-config
   ];
 


### PR DESCRIPTION
Upgrade to the newly available Rust 1.69.0.

This commit can be used as a reference for how to upgrade Rust with `rust-overlay`.