### PR TITLE
GHA: Upgrade actions/checkout to v4.1.1

### DIFF
--- a/.github/workflows/r10e-cross-rs-build.yml
+++ b/.github/workflows/r10e-cross-rs-build.yml
@@ -23,7 +23,7 @@ jobs:
       runs-on: ${{ matrix.os }}
       steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
       - name: Cross build artifacts
         run: |
           cd ${{ github.workspace }}

--- a/.github/workflows/r10e-rust-overlay-build.yml
+++ b/.github/workflows/r10e-rust-overlay-build.yml
@@ -23,7 +23,7 @@ jobs:
       runs-on: ${{ matrix.os }}
       steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
       - name: Cross build artifacts
         run: |
           cd ${{ github.workspace }}


### PR DESCRIPTION
This is to move away from the deprecated node 12.