### PR TITLE
rust-overlay: upgrade rust-bin to 1.78.0 (1.77.0 for x86_64-win builds)

### DIFF
--- a/nix-rust-overlay/Dockerfile
+++ b/nix-rust-overlay/Dockerfile
@@ -10,8 +10,11 @@ ENV RUST_PROJECT_NAME="rust-cross-build-nix"
 
 # nixpkgs 22.05
 ENV NIXPKGS_COMMIT_SHA="ce6aa13369b667ac2542593170993504932eb836"
-# rust-overlay version 20240303
-ENV RUST_OVERLAY_COMMIT_SHA="30c3af18405567115958c577c62548bdc5a251e7"
+# rust-overlay version 20240502 with latest rust-bin.stable 1.78.0
+# Note that this is the previous commit of the problematic commit
+# 0bf05d8534406776a0fbc9ed8d4ef5bd925b056a that seemed to have introduced a
+# breaking change
+ENV RUST_OVERLAY_COMMIT_SHA="2e7ccf572ce0f0547d4cf4426de4482936882d0e"
 
 # Apple M1 workaround
 COPY nix.conf /build/nix.conf

--- a/nix-rust-overlay/shell-aarch64.nix
+++ b/nix-rust-overlay/shell-aarch64.nix
@@ -8,7 +8,7 @@
 { mkShell, stdenv, rust-bin, pkg-config, openssl, qemu }:
 mkShell {
   nativeBuildInputs = [
-    rust-bin.stable."1.76.0".minimal
+    rust-bin.stable."1.78.0".minimal
     pkg-config
   ];
 

--- a/nix-rust-overlay/shell-armv6.nix
+++ b/nix-rust-overlay/shell-armv6.nix
@@ -8,7 +8,7 @@
 { mkShell, stdenv, rust-bin, pkg-config, openssl, qemu }:
 mkShell {
   nativeBuildInputs = [
-    rust-bin.stable."1.76.0".minimal
+    rust-bin.stable."1.78.0".minimal
     pkg-config
   ];
 

--- a/nix-rust-overlay/shell-armv7.nix
+++ b/nix-rust-overlay/shell-armv7.nix
@@ -8,7 +8,7 @@
 { mkShell, stdenv, rust-bin, pkg-config, openssl, qemu }:
 mkShell {
   nativeBuildInputs = [
-    rust-bin.stable."1.76.0".minimal
+    rust-bin.stable."1.78.0".minimal
     pkg-config
   ];
 

--- a/nix-rust-overlay/shell-i686.nix
+++ b/nix-rust-overlay/shell-i686.nix
@@ -8,7 +8,7 @@
 { mkShell, stdenv, rust-bin, pkg-config, openssl, qemu }:
 mkShell {
   nativeBuildInputs = [
-    rust-bin.stable."1.76.0".minimal
+    rust-bin.stable."1.78.0".minimal
     pkg-config
   ];
 

--- a/nix-rust-overlay/shell-x86_64-win.nix
+++ b/nix-rust-overlay/shell-x86_64-win.nix
@@ -10,7 +10,7 @@
 { mkShell, stdenv, rust-bin, windows, wine64, pkg-config }:
 mkShell {
   nativeBuildInputs = [
-    rust-bin.stable."1.78.0".minimal
+    rust-bin.stable."1.77.0".minimal
     pkg-config
   ];
 

--- a/nix-rust-overlay/shell-x86_64-win.nix
+++ b/nix-rust-overlay/shell-x86_64-win.nix
@@ -10,7 +10,7 @@
 { mkShell, stdenv, rust-bin, windows, wine64, pkg-config }:
 mkShell {
   nativeBuildInputs = [
-    rust-bin.stable."1.76.0".minimal
+    rust-bin.stable."1.78.0".minimal
     pkg-config
   ];
 

--- a/nix-rust-overlay/shell-x86_64.nix
+++ b/nix-rust-overlay/shell-x86_64.nix
@@ -8,7 +8,7 @@
 { mkShell, stdenv, rust-bin, pkg-config, openssl, qemu }:
 mkShell {
   nativeBuildInputs = [
-    rust-bin.stable."1.76.0".minimal
+    rust-bin.stable."1.78.0".minimal
     pkg-config
   ];
 


### PR DESCRIPTION
Upgrade rust to 1.78.0, which is the highest available version of the stable rust-bin before a breaking change was introduced in May 2024. We will need to debug the build failure before using a later version of rust-overlay.